### PR TITLE
.hbs files

### DIFF
--- a/Syntaxes/Handlebars.tmLanguage
+++ b/Syntaxes/Handlebars.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>handlebars</string>
+                <string>hbs</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(?x)


### PR DESCRIPTION
Hey Nic,

it's kind of a habit for me (and I think many others) to use the .hbs extension for handlebar files. Just added them to the list of files for the Handlebars language.

Cheers,

Thorben
